### PR TITLE
Fix parent folder path

### DIFF
--- a/chatstats.py
+++ b/chatstats.py
@@ -175,7 +175,7 @@ def main(argv):
         json_file = "{}{}".format(chat_folder, CHAT_FILE)
 
     # get the parent folder of the messages directory
-    parent_folder = os.path.dirname(os.path.dirname(os.path.dirname(chat_folder)))
+    parent_folder = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(chat_folder))))
 
     # open json file as dict
     json_data = json.loads(open(json_file).read())


### PR DESCRIPTION
Was getting an error when I was trying to run `python3 chatstats.py <chat_folder>`, so I changed the `parent_folder`

```
Traceback (most recent call last):
  File "chatstats.py", line 207, in <module>
    main(sys.argv)
  File "chatstats.py", line 191, in main
    grapher.graph(messages, output_folder, parent_folder)
  File "/Users/katrina/Documents/chatstats/grapher.py", line 241, in graph
    img =  plt.imread(file)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/matplotlib/pyplot.py", line 2152, in imread
    return matplotlib.image.imread(fname, format)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/matplotlib/image.py", line 1374, in imread
    with open(fname, 'rb') as fd:
FileNotFoundError: [Errno 2] No such file or directory: '/Users/katrina/Documents/messages/messages/stickers_used/47213930_937342053129740_4671021103290777600_n_167788263418460.png'
```

So fun having the graphs, ur a beast for building! 🔥 